### PR TITLE
Feature: Allow execution of random queries during cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The cleanup service will execute cleanup jobs that are specified in the SPARQL e
 - `cleanup:selectPattern`: the pattern to match; resource to be deleted should be named `?resource`. This is used in COUNT queries and the cleanup query (a `DELETE...WHERE` query). Needs to specified in conjunction with `cleanup:deletePattern`.
 - `cleanup:deletePattern`: the pattern to be deleted. Needs to specified in conjuntion with `cleanup:selectPattern`.
 - `cleanup:cronPattern` (optional): a cron pattern to schedule the job execution. If not provided, the default pattern will be used.
-- `cleanup:randomQuery`: If a random query just needs exection; specify the query here. Mutually exclusive with other patterns.
+- `cleanup:randomQuery`: If a random query needs exection, specify the query here. Mutually exclusive with other patterns.
 These jobs are located in `http://mu.semte.ch/graphs/public` graph, and additional migrations can be added to the migration folder of your stack or directly through your SPARQL editor.
 
 For example:
@@ -65,6 +65,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
 ```
 
 Another example, which executes a random query:
+
 ```sparql
 PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
 PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ services:
 The cleanup service will execute cleanup jobs that are specified in the SPARQL endpoint. Each job should have the type `cleanup:Job` and at least the following properties:
 - `mu:uuid`: an identifier for the job, typically the last part of its URI
 - `dcterms:title`: a title describing the job
-- `cleanup:selectPattern`: the pattern to match; resource to be deleted should be named `?resource`. This is used in COUNT queries and the cleanup query (a `DELETE...WHERE` query)
-- `cleanup:deletePattern`: the pattern to be deleted
+- `cleanup:selectPattern`: the pattern to match; resource to be deleted should be named `?resource`. This is used in COUNT queries and the cleanup query (a `DELETE...WHERE` query). Needs to specified in conjunction with `cleanup:deletePattern`.
+- `cleanup:deletePattern`: the pattern to be deleted. Needs to specified in conjuntion with `cleanup:selectPattern`.
 - `cleanup:cronPattern` (optional): a cron pattern to schedule the job execution. If not provided, the default pattern will be used.
-
+- `cleanup:randomQuery`: If a random query just needs exection; specify the query here. Mutually exclusive with other patterns.
 These jobs are located in `http://mu.semte.ch/graphs/public` graph, and additional migrations can be added to the migration folder of your stack or directly through your SPARQL editor.
 
 For example:
@@ -43,7 +43,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
       ?source ?sourcep ?sourceo .
 
       BIND(NOW() - xsd:dayTimeDuration("P1D") AS ?oneDayAgo)
-      FILTER(?modified <= ?oneDayAgo)
+     FILTER(?modified <= ?oneDayAgo)
       FILTER(NOT EXISTS { ?foo <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> ?resource })
     }
     """;
@@ -53,7 +53,25 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
       ?source ?sourcep ?sourceo.
     }
     """;
-  cleanup:cronPattern "0 0 * * *"; # Runs daily at midnight
+  cleanup:cronPattern "0 0 * * *". # Runs daily at midnight
+```
+
+Other example, executing a random query:
+```sparql
+PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX mu:      <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+
+:job a cleanup:Job;
+  mu:uuid "ecf0c526-04bb-4e16-86a2-85b5a62cb849";
+  dcterms:title "Flush a triple in a graph";
+  cleanup:randomQuery """
+    DELETE DATA {
+      GRAPH <http://a/graph/ecf0c526-04bb-4e16-86a2-85b5a62cb849> {
+        <http://ecf0c526-04bb-4e16-86a2-85b5a62cb849> <http://bar> <http://baz>.
+    }
+    """;;
+  cleanup:cronPattern "0 0 * * *". # Runs daily at midnight
 ```
 
 **Note that a graph is specified in each pattern; this is needed in order to run the query.**

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -17,6 +17,7 @@ class CleanupJob {
     description,
     selectPattern,
     deletePattern,
+    randomQuery,
     cronPattern,
   }) {
     this.id = id;
@@ -25,37 +26,42 @@ class CleanupJob {
     this.description = description;
     this.selectPattern = selectPattern;
     this.deletePattern = deletePattern;
+    this.randomQuery = randomQuery;
     this.cronPattern = cronPattern;
   }
 
   async execute() {
     console.log(`Running cleanup job "${this.title}" (ID: ${this.id})`);
 
-    let resources;
-    try {
-      resources = await this.matchingResources();
-    } catch (e) {
-      console.error('Error fetching matching resources:', e);
-      return;
-    }
-
-    if (!resources || resources.length === 0) {
-      console.warn('No resources were found.');
-      return;
-    }
-
-    console.log(`Found ${resources.length} matches to remove`);
-
-    for (let resource of resources) {
+    if(this.selectPattern && this.deletePattern) {
+      let resources;
       try {
-        console.log(`Removing resource: ${resource}`);
-        await this.removeResource(resource);
+        resources = await this.matchingResources();
       } catch (e) {
-        console.warn(`Failed to remove resource: ${resource}`);
-        console.error(e);
+        console.error('Error fetching matching resources:', e);
+        return;
+      }
+
+      if (!resources || resources.length === 0) {
+        console.warn('No resources were found.');
+        return;
+      }
+
+      console.log(`Found ${resources.length} matches to remove`);
+
+      for (let resource of resources) {
+        try {
+          console.log(`Removing resource: ${resource}`);
+          await this.removeResource(resource);
+        } catch (e) {
+          console.warn(`Failed to remove resource: ${resource}`);
+          console.error(e);
+        }
       }
     }
-
+    else {
+      await this.executeRandomQuery();
+    }
     console.log('Cleanup job done.');
   }
 
@@ -113,20 +119,36 @@ class CleanupJob {
     }
   }
 
+  async executeRandomQuery() {
+    try {
+      console.log(`Executing random query: \n ${this.randomQuery}`);
+      await update(this.randomQuery, {}, sparqlConnectionOptions);
+    }
+    catch (e) {
+      console.error('Error executing random query: ', e);
+      throw e;
+    }
+  }
+
   static async findAll() {
     const result = await query(`
       PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
       PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
       PREFIX dcterms: <http://purl.org/dc/terms/>
 
-      SELECT ?uri ?id ?title ?description ?selectPattern ?deletePattern ?cronPattern
+      SELECT ?uri ?id ?title ?description ?selectPattern ?deletePattern ?cronPattern ?randomQuery
       FROM <${graph}>
       WHERE {
         ?uri a cleanup:Job ;
           mu:uuid ?id ;
-          dcterms:title ?title ;
-          cleanup:selectPattern ?selectPattern ;
-          cleanup:deletePattern ?deletePattern .
+          dcterms:title ?title.
+
+        {
+          ?uri cleanup:selectPattern ?selectPattern ;
+            cleanup:deletePattern ?deletePattern .
+        } UNION {
+          ?uri cleanup:randomQuery ?randomQuery.
+        }
 
         OPTIONAL { ?uri dcterms:description ?description . }
         OPTIONAL { ?uri cleanup:cronPattern ?cronPattern . }

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -33,7 +33,7 @@ class CleanupJob {
   async execute() {
     console.log(`Running cleanup job "${this.title}" (ID: ${this.id})`);
 
-    if(this.selectPattern && this.deletePattern) {
+    if (this.selectPattern && this.deletePattern) {
       let resources;
       try {
         resources = await this.matchingResources();
@@ -47,7 +47,7 @@ class CleanupJob {
         return;
       }
 
-      console.log(`Found ${resources.length} matches to remove`);
+      console.log(`Found ${resources.length} match(es) to remove.`);
 
       for (let resource of resources) {
         try {
@@ -58,11 +58,12 @@ class CleanupJob {
           console.error(e);
         }
       }
-    }
-    else {
+
+      console.log('Cleanup job done.');
+    } else {
       await this.executeRandomQuery();
+      console.log('Random query executed.');
     }
-    console.log('Cleanup job done.');
   }
 
   /**
@@ -141,13 +142,13 @@ class CleanupJob {
       WHERE {
         ?uri a cleanup:Job ;
           mu:uuid ?id ;
-          dcterms:title ?title.
+          dcterms:title ?title .
 
         {
           ?uri cleanup:selectPattern ?selectPattern ;
             cleanup:deletePattern ?deletePattern .
         } UNION {
-          ?uri cleanup:randomQuery ?randomQuery.
+          ?uri cleanup:randomQuery ?randomQuery .
         }
 
         OPTIONAL { ?uri dcterms:description ?description . }

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -61,8 +61,13 @@ class CleanupJob {
 
       console.log('Cleanup job done.');
     } else {
-      await this.executeRandomQuery();
-      console.log('Random query executed.');
+      try {
+        await this.executeRandomQuery();
+        console.log('Random query executed.');
+      } catch (e) {
+        console.warn('Failed to execute random query.');
+        console.error(e);
+      }
     }
   }
 


### PR DESCRIPTION
This was a missing feature that has now been added. Over time, we might decide to revise the other patterns and evolve towards a periodic migration service?

Note: A bit tricky merge, first ensure https://github.com/lblod/db-cleanup-service/pull/4 is merged, and then be VERY attentive in merging and resolving the conflicts when merging this PR.