### PR TITLE
Bugfix/schedule jobs on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
 PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 
-:job a cleanup:Job;
-  mu:uuid "10724bc2-c9d0-4a35-a499-91a8b7cb023b";
-  dcterms:title "clean up dangling file uploads";
+:job a cleanup:Job ;
+  mu:uuid "10724bc2-c9d0-4a35-a499-91a8b7cb023b" ;
+  dcterms:title "clean up dangling file uploads" ;
   cleanup:selectPattern """
     GRAPH <http://mu.semte.ch/graphs/public> {
       ?resource a <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#FileDataObject> ;
@@ -54,14 +54,14 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
       FILTER(?modified <= ?oneDayAgo)
       FILTER(NOT EXISTS { ?foo <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#hasPart> ?resource })
     }
-    """;
+    """ ;
   cleanup:deletePattern """
     GRAPH <http://mu.semte.ch/graphs/public> {
-      ?resource ?p ?o.
-      ?source ?sourcep ?sourceo.
+      ?resource ?p ?o .
+      ?source ?sourcep ?sourceo .
     }
-    """;
-  cleanup:cronPattern "0 0 * * *". # Runs daily at midnight
+    """ ;
+  cleanup:cronPattern "0 0 * * *" . # Runs daily at midnight
 ```
 
 **Note that a graph is specified in each pattern; this is needed in order to run the query.**

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example:
 
 ```sparql
 PREFIX cleanup: <http://mu.semte.ch/vocabularies/ext/cleanup/>
-PREFIX mu:      <http://mu.semte.ch/vocabularies/ext/cleanup/>
+PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 
 :job a cleanup:Job;
@@ -53,7 +53,7 @@ PREFIX dcterms: <http://purl.org/dc/terms/>
       ?source ?sourcep ?sourceo.
     }
     """;
-  cleanup:cronPattern "0 0 * * *"; # Runs daily at midnight
+  cleanup:cronPattern "0 0 * * *". # Runs daily at midnight
 ```
 
 **Note that a graph is specified in each pattern; this is needed in order to run the query.**

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ services:
     image: lblod/db-cleanup-service:x.y.z
 ```
 
+## Environment Variables
+
+| Name                        | Description                                                                   | Type      |
+| --------------------------- | ----------------------------------------------------------------------------- | ---------
+| `SPARQL_ENDPOINT`           | The endpoint that will receive SPARQL queries                                 | UrlString |
+| `PING_DB_INTERVAL`          | Interval (ms) to wait before pinging to confirm if the database is running    | Int       |
+| `SCHEDULE_ON_SERVICE_START` | Allows the cleanup jobs to be automatically scheduled when the service starts | Bool      |
+
 ## Configuration
 
 The cleanup service will execute cleanup jobs that are specified in the SPARQL endpoint. Each job should have the type `cleanup:Job` and at least the following properties:

--- a/app.js
+++ b/app.js
@@ -2,11 +2,12 @@ import cron from 'node-cron';
 import { app, errorHandler } from 'mu';
 import CleanupJob from './jobs/cleanup-job';
 import scheduleCleanupJob from './jobs/schedule-cleanup-job';
+import { waitForDatabase } from './database-utils';
 
 const scheduleAllCleanups = async function() {
   const jobs = await CleanupJob.findAll();
   for (let job of jobs) {
-    console.log(`Creating cronjob with ID: ${job.id}`);
+    console.log(`Scheduling job with ID: ${job.id}, entitled: "${job.title}"`);
     scheduleCleanupJob(job);
   }
 };
@@ -17,7 +18,9 @@ const disableCronjobs = async function() {
     job.stop();
     console.log(`Stopped cronjob with ID: ${jobId}`);
   }
-}
+};
+
+waitForDatabase().then(scheduleAllCleanups);
 
 app.post('/cleanup', async function( req, res, next ) {
   try {

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import { app, errorHandler } from 'mu';
 import CleanupJob from './jobs/cleanup-job';
 import scheduleCleanupJob from './jobs/schedule-cleanup-job';
 import { waitForDatabase } from './database-utils';
+import * as env from './env';
 
 const scheduleAllCleanups = async function() {
   const jobs = await CleanupJob.findAll();
@@ -20,7 +21,12 @@ const disableCronjobs = async function() {
   }
 };
 
-waitForDatabase().then(scheduleAllCleanups);
+// If a user wants the jobs to be scheduled as the service starts,
+// the service first checks if the database is online and proceeds to schedule
+// the cleanup jobs.
+if (env.SCHEDULE_ON_SERVICE_START) {
+  waitForDatabase().then(scheduleAllCleanups);
+}
 
 app.post('/cleanup', async function( req, res, next ) {
   try {

--- a/database-utils.js
+++ b/database-utils.js
@@ -1,14 +1,15 @@
 import { querySudo as query } from '@lblod/mu-auth-sudo';
-//courtesy @claire-lovisa
-const pingDbInterval = parseInt(process.env.PING_DB_INTERVAL || 2);
+
+// Courtesy of @claire-lovisa
+const pingDbInterval = parseInt(process.env.PING_DB_INTERVAL) || 2; // Milliseconds
 
 const isDatabaseUp = async function() {
   let isUp = false;
   try {
-    await sendDumyQuery();
+    await sendDummyQuery();
     isUp = true;
   } catch (e) {
-    console.log("Waiting for database... ");
+    console.log("Waiting for database...");
   }
   return isUp;
 };
@@ -21,11 +22,11 @@ const waitForDatabase = async function() {
   let loop = true;
   while (loop) {
     loop = !(await isDatabaseUp());
-    await sleep(pingDbInterval*1000);
+    await sleep(pingDbInterval * 1000);
   }
 };
 
-const sendDumyQuery = async function() {
+const sendDummyQuery = async function() {
   try {
     const result = await query(`
       SELECT ?s

--- a/database-utils.js
+++ b/database-utils.js
@@ -1,7 +1,7 @@
 import { querySudo as query } from '@lblod/mu-auth-sudo';
+import * as env from './env';
 
 // Courtesy of @claire-lovisa
-const pingDbInterval = parseInt(process.env.PING_DB_INTERVAL) || 2; // Milliseconds
 
 const isDatabaseUp = async function() {
   let isUp = false;
@@ -22,7 +22,7 @@ const waitForDatabase = async function() {
   let loop = true;
   while (loop) {
     loop = !(await isDatabaseUp());
-    await sleep(pingDbInterval * 1000);
+    await sleep(env.PING_DB_INTERVAL * 1000);
   }
 };
 

--- a/database-utils.js
+++ b/database-utils.js
@@ -1,0 +1,44 @@
+import { querySudo as query } from '@lblod/mu-auth-sudo';
+//courtesy @claire-lovisa
+const pingDbInterval = parseInt(process.env.PING_DB_INTERVAL || 2);
+
+const isDatabaseUp = async function() {
+  let isUp = false;
+  try {
+    await sendDumyQuery();
+    isUp = true;
+  } catch (e) {
+    console.log("Waiting for database... ");
+  }
+  return isUp;
+};
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+const waitForDatabase = async function() {
+  let loop = true;
+  while (loop) {
+    loop = !(await isDatabaseUp());
+    await sleep(pingDbInterval*1000);
+  }
+};
+
+const sendDumyQuery = async function() {
+  try {
+    const result = await query(`
+      SELECT ?s
+      WHERE {
+        GRAPH ?g {
+          ?s ?p ?o
+        }
+      }
+      LIMIT 1
+    `);
+  } catch (e) {
+    throw new Error(e.toString());
+  }
+};
+
+export { waitForDatabase }

--- a/env.js
+++ b/env.js
@@ -9,3 +9,8 @@ export const PING_DB_INTERVAL = envvar
   .get('PING_DB_INTERVAL')
   .default(2) // 2 milliseconds
   .asInt();
+
+export const SCHEDULE_ON_SERVICE_START = envvar
+  .get('SCHEDULE_ON_SERVICE_START')
+  .default('true')
+  .asBool();

--- a/env.js
+++ b/env.js
@@ -1,7 +1,7 @@
 import envvar from 'env-var';
 
-export const SPARQL_ENDPOINT_CLEANUP_OPERATIONS = envvar
-  .get('SPARQL_ENDPOINT_CLEANUP_OPERATIONS')
+export const SPARQL_ENDPOINT = envvar
+  .get('SPARQL_ENDPOINT')
   .default('http://database:8890/sparql')
   .asUrlString();
 

--- a/env.js
+++ b/env.js
@@ -4,3 +4,8 @@ export const SPARQL_ENDPOINT_CLEANUP_OPERATIONS = envvar
   .get('SPARQL_ENDPOINT_CLEANUP_OPERATIONS')
   .default('http://database:8890/sparql')
   .asUrlString();
+
+export const PING_DB_INTERVAL = envvar
+  .get('PING_DB_INTERVAL')
+  .default(2) // 2 milliseconds
+  .asInt();

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -119,7 +119,8 @@ class CleanupJob {
       PREFIX mu:      <http://mu.semte.ch/vocabularies/core/>
       PREFIX dcterms: <http://purl.org/dc/terms/>
 
-      SELECT ?uri ?id ?title ?description ?selectPattern ?deletePattern ?cronPattern
+      SELECT DISTINCT ?uri ?id ?title ?description ?selectPattern ?deletePattern ?cronPattern
+
       FROM <${graph}>
       WHERE {
         ?uri a cleanup:Job ;

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -120,7 +120,6 @@ class CleanupJob {
       PREFIX dcterms: <http://purl.org/dc/terms/>
 
       SELECT DISTINCT ?uri ?id ?title ?description ?selectPattern ?deletePattern ?cronPattern
-
       FROM <${graph}>
       WHERE {
         ?uri a cleanup:Job ;

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -5,7 +5,7 @@ import * as env from '../env';
 const graph = process.env.MU_APPLICATION_GRAPH;
 
 const sparqlConnectionOptions = {
-  sparqlEndpoint: env.SPARQL_ENDPOINT_CLEANUP_OPERATIONS,
+  sparqlEndpoint: env.SPARQL_ENDPOINT,
   mayRetry: true,
 };
 


### PR DESCRIPTION
An important feature went missing during the refactor: the scheduling of jobs at the start of the service. This feature has now been restored.

Note: Since the flow has changed, jobs may now have their own schedules and can be programmed in the database. We need to wait for the database to come up before starting the scheduling. This contrasts with the previous flow, where jobs were controlled by a single programmatically defined cron pattern.