### PR TITLE
Rename sparql endpoint environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ services:
 
 | Name                        | Description                                                                   | Type      |
 | --------------------------- | ----------------------------------------------------------------------------- | ---------
-| `SPARQL_ENDPOINT`           | The endpoint that will receive SPARQL queries                                 | UrlString |
+| `MU_SPARQL_ENDPOINT`        | The endpoint that will receive SPARQL queries                                 | UrlString |
 | `MU_APPLICATION_GRAPH`      | Graph containing the cleanup jobs                                             | UrlString |
 | `CRON_PATTERN`              | Default cron pattern for cleanup jobs that do not define one                  | String    |
 | `PING_DB_INTERVAL`          | Interval (ms) to wait before pinging to confirm if the database is running    | Int       |

--- a/env.js
+++ b/env.js
@@ -1,7 +1,7 @@
 import envvar from 'env-var';
 
-export const SPARQL_ENDPOINT = envvar
-  .get('SPARQL_ENDPOINT')
+export const MU_SPARQL_ENDPOINT = envvar
+  .get('MU_SPARQL_ENDPOINT')
   .default('http://database:8890/sparql')
   .asUrlString();
 

--- a/jobs/cleanup-job.js
+++ b/jobs/cleanup-job.js
@@ -5,7 +5,7 @@ import * as env from '../env';
 const graph = env.MU_APPLICATION_GRAPH;
 
 const sparqlConnectionOptions = {
-  sparqlEndpoint: env.SPARQL_ENDPOINT,
+  sparqlEndpoint: env.MU_SPARQL_ENDPOINT,
   mayRetry: true,
 };
 


### PR DESCRIPTION
## Description

Rename SPARQL_ENDPOINT to MU_SPARQL_ENDPOINT to avoid having two environment variables for the endpoint.